### PR TITLE
Implement commands in USER subroutine

### DIFF
--- a/nullbios/biosstart.S
+++ b/nullbios/biosstart.S
@@ -69,10 +69,10 @@ GAME_CARTRIDGE_VECTORS:
  * BIOS public calls, exported in a jmp table
  */
         .org    0x438
-        jmp     SYSTEM_INT1             /* VBlank handler during boot     */
-        jmp     SYSTEM_INT2             /* Timer handler                  */
+        jmp     SYSTEM_INT1.l           /* VBlank handler during boot     */
+        jmp     SYSTEM_INT2.l           /* Timer handler                  */
+        jmp     SYSTEM_RETURN.l         /* Return from USER subroutine    */
 .if 0
-        jmp     SYSTEM_RETURN
         jmp     SYSTEM_IO               /* Status of coins, joysticks...  */
         jmp     CREDIT_CHECK            /* Check credit for players       */
         jmp     CREDIT_DOWN             /* Decrement credits              */
@@ -101,18 +101,33 @@ GAME_CARTRIDGE_VECTORS:
  */
 RESET:
         /* Supervisor, init IRQ and watchdog timer */
-       	move    #0x2700, %sr
-	move.w	#7, 0x3c000c
-	move.b	%d0, 0x300001
+        move    #0x2700, %sr
+        move.w  #7, 0x3c000c
+        move.b  %d0, 0x300001
 
-	/* Switch to cart's ROMs (gfx, sound, vector table...) */
-      	move.b	#1, 0x3a0013
-      	move.b	#1, 0x3a001b
+        /* Prepare to call USER's request 0 (SystemInit) */
+        clr     %d0
+        move.b  %d0, 0x10fdae
+        move.b  %d0, 0x10fdaf
+        jsr     0x122
 
-	/* Mark init as done, and jmp to cart's main function */
+.Lsoft_reset:
+        /* Switch to cart's ROMs (gfx, sound, vector table...) */
+        move.b  #1, 0x3a0013
+        move.b  #1, 0x3a001b
+
+        /* Mark init as done, and start the GAME's main function
+         * by calling USER's request 2 (Game)
+         */
         move    #0x2000, %sr
-	bset    #7, 0x10fd80
+        bset    #7, 0x10fd80
+        move.b  #2, 0x10fdae
+        move.b  #1, 0x10fdaf
         jmp.l   0x122
+
+        /* Reset the game if it returned to the BIOS */
+        jmp     .Lsoft_reset
+
 
 /**
  * Default VBlank handler
@@ -133,6 +148,14 @@ SYSTEM_INT2:
 	move.b  %d0, 0x300001
         rte
 
+
+/**
+ * Return from USER subroutine
+ * USER jmp to here, so the ret should go back
+ * to to the last jsr 0x122 done in function RESET
+ */
+SYSTEM_RETURN:
+        rts
 
 /**
  * Ignore

--- a/runtime/ngdevkit-crt0.S
+++ b/runtime/ngdevkit-crt0.S
@@ -20,6 +20,11 @@
 	.global	rom_info_default
 	.global rom_handler_VBlank_default
 	.global rom_handler_Timer_default
+	.global rom_mvs_startup_init_default
+	.global rom_eye_catcher_default
+	.global rom_game_default
+	.global rom_title_default
+
 _start:
         /* 68k exception vector table, 256 bytes
          * Common exceptions point to handlers implemented in the BIOS
@@ -65,12 +70,13 @@ _start:
 	dc.l	rom_info_EU
 
 	/* ROM Entry Point */
-	jmp     GAME_BOOT.l
-	jmp     .LStart2.l
-	jmp     .LStart3.l
+	jmp     USER.l
+	jmp     PLAYER_START.l
+	jmp     DEMO_END.l
+	jmp     COIN_SOUND.l
 
 	/* ...to be described... */
-	.fill	76, 1, 0xff
+	.fill	70, 1, 0xff
 	dc.w	0x0000
 
 	/* Pointer to the Security Code (Unique sequence of 61 words) */
@@ -137,7 +143,6 @@ rom_handler_Timer_default:
         /* Ack IRQ and rearm watchdog timer */
 	move.w  #2, 0x3c000c
 	move.b  %d0, 0x300001
-        
 	/* If user handler exists for Hblank, call it */
 	movem.l	%d0-%d7/%a0-%a7, -(%sp)
 	move.l	#rom_callback_Timer, %d0
@@ -151,20 +156,20 @@ rom_handler_Timer_default:
 
 
 /*
- * Main entry point
+ * MVS-only: run once when the cartridge is run for
+ * the first time in the cabinet.
+ * (in emulators like MAME, you can trigger that code
+ *  by removing the nvram saved state)
  */
-GAME_BOOT:
-	/* Disable IRQs, as we don't want C code to be
-         * called prior to runtime initialization
-         */
-	move    #0x2700, %sr
-        /* Ack pending IRQ and rearm watchdog timer */
-	move.w	#7, 0x3c000c
-	move.b	%d0, 0x300001
+rom_mvs_startup_init_default:
+        /* Rearm watchdog timer before init */
+        move.b	%d0, 0x300001
+        rts
 
-	/* Switch to fix tiles from user bank */
-	move.b	#1, 0x3a001b
-
+/*
+ * Load the data and BSS segments in RAM
+ */
+init_c_runtime:
 	/* copy data segment from ROM to RAM */
 	move.l	#__data_end, %d0
 	sub.l	#__data_start, %d0
@@ -186,16 +191,79 @@ GAME_BOOT:
 	move.l	#__bss_end, %d0
 	sub.l	#__bss_start, %d0
 	tst	%d0
-	beq	.Lcallmain
+	beq	.Linitdone
 .Lcopybss:
 	move.b	#0, (%a0)+
 	move.b	%d0, 0x300001
 	dbra	%d0, .Lcopybss
 
-.Lcallmain:
-	/* Enable interrupts and call program's main */
-	move    #0x2000, %sr
-	jsr	main.l
+.Linitdone:
+        rts
+
+
+rom_eye_catcher_default:
+rom_game_default:
+rom_title_default:
+        /* Disable IRQs, as we don't want C code to be
+         * called prior to runtime initialization
+         */
+        move    #0x2700, %sr
+
+        /* Ack pending IRQ and rearm watchdog timer */
+        move.w  #7, 0x3c000c
+        move.b  %d0, 0x300001
+
+        /* Init the C part of the game cartridge */
+        jsr init_c_runtime
+
+        /* Switch to fix tiles from user bank */
+        move.b	#1, 0x3a001b
+
+        /* Enable interrupts and call game's main */
+        move	#0x2000, %sr
+        jsr	main.l
+
+        /* if main returns, give back control to USER */
+        rts
+
+/*
+ * User request: main entry points, called by BIOS
+ * When the symbols in the jump table below are not
+ * implemented in the game cartridge, the linkscript
+ * uses the default functions from this crt0 instead.
+ */
+.Luser_commands:
+        dc.l    rom_mvs_startup_init  /* 0: StartupInit */
+        dc.l	rom_eye_catcher       /* 1: EyeCatcher */
+        dc.l	rom_game              /* 2: Game */
+        dc.l	rom_title             /* 3: Title */
+USER:
+        /* Rearm watchdog */
+        move.b	%d0, 0x300001
+
+        /* Get user command requested by BIOS */
+        clr.l	%d0
+        move.b	0x10fdae, %d0
+        lsl.b	#2, %d0
+        lea	.Luser_commands, %a0
+        movea.l	(%a0,%d0),%a0
+
+        /* Execute the command and go back to BIOS */
+        jsr	(%a0)
+        jmp	0xc00444
+
+
+PLAYER_START:
+        rts
+
+
+DEMO_END:
+        rts
+
+
+COIN_SOUND:
+        rts
+
 
 .Lidle:	bra	.Lidle
 
@@ -205,9 +273,3 @@ GAME_BOOT:
 	 * do nothing until a reset occurs.
 	 */
 	jmp	.Lidle.l
-
-.LStart2:
-    rts
-
-.LStart3:
-    rts

--- a/runtime/ngdevkit.ld
+++ b/runtime/ngdevkit.ld
@@ -57,6 +57,12 @@ SECTIONS {
     rom_callback_VBlank = DEFINED( rom_callback_VBlank)? rom_callback_VBlank : 0;
     rom_callback_Timer = DEFINED( rom_callback_Timer)? rom_callback_Timer : 0;
 
+    /* USER commands: use cartridge overrides or the defaults from crt0 */
+    rom_mvs_startup_init = DEFINED(rom_mvs_startup_init)? rom_mvs_startup_init : rom_mvs_startup_init_default;
+    rom_eye_catcher = DEFINED(rom_eye_catcher)? rom_eye_catcher : rom_eye_catcher_default;
+    rom_game = DEFINED(rom_game)? rom_game : rom_game_default;
+    rom_title = DEFINED(rom_title)? rom_title : rom_title_default;
+
     *(.ctors)
     *(.dtors)
     *(.eh_frame)


### PR DESCRIPTION
Currently the game boots straight to the C's main function, without
honoring the various initial command calls that the Neo Geo BIOS may
request at startup. This prevents the Eye Catcher animation from
showing properly.

Fix that by implementing implementing the request calls as expected
by the BIOS. Make nullbios mimick that behaviour as well.

The default is now to jump to C's main only after the Eye Catcher,
but that behaviour can be overriden by providing your own functions
with the same name (the link script will use them automatically).

Closes #11