### PR TITLE
Do not install into ngdevkit-toolchain's prefix

### DIFF
--- a/runtime/Makefile.in
+++ b/runtime/Makefile.in
@@ -36,12 +36,12 @@ ngdevkit-specs:
 install: install-objs install-specs
 
 install-objs: $(OBJS) ngdevkit.ld
-	DIR=$(DESTDIR)$$(dirname $$($(NGGCC) --print-file-name=crt0.o)) && \
+	DIR=$(DESTDIR)$(prefix)/$$(dirname $$($(NGGCC) --print-file-name=crt0.o) | sed -n 's%^.*\(m68k-neogeo-elf/lib/gcc\)%\1%p') && \
 	$(INSTALL) -d $$DIR && $(INSTALL) $^ $$DIR
 
 install-specs: ngdevkit-specs
-	DIR=$(DESTDIR)$$(dirname $$($(NGGCC) --print-libgcc-file-name)) && \
-	$(INSTALL) -d $$DIR && $(INSTALL) $< -t $$DIR
+	DIR=$(DESTDIR)$(prefix)/$$(dirname $$($(NGGCC) --print-libgcc-file-name) | sed -n 's%^.*\(m68k-neogeo-elf/lib/gcc\)%\1%p') && \
+	$(INSTALL) -d $$DIR && $(INSTALL) $< $$DIR
 
 clean:
 	rm -f *.o *~ *.a ngdevkit-specs


### PR DESCRIPTION
Various runtime files (e.g. crt0) were installed in gcc's install path.
This extrapolated install location is not valid when every git module
is installed in a separate prefix, as is it the case for instance with
brew in macOS.

Fix the install to split the install paths if needed, and stick to
the original merged path otherwise.