### PR TITLE
adding missing command to enter examples directory

### DIFF
--- a/README-mingw.md
+++ b/README-mingw.md
@@ -71,6 +71,7 @@ reference that path with the equivalent WSL mount point as follows:
 You can now clone the examples and compile them with:
 
     git clone --recursive https://github.com/dciabrin/ngdevkit-examples examples
+    cd examples
     autoreconf -iv
     ./configure --enable-mingw
     make


### PR DESCRIPTION
*before this, the following error message was displayed*
`kl3mousse@klem-xps-w10:~/neogeo$ autoreconf -iv
autoreconf: 'configure.ac' or 'configure.in' is required`

I guess a little `cd` command was missing there to enter examples folder.