### PR TITLE
Optimize C runtime initialization for speed over size

### DIFF
--- a/runtime/ngdevkit-crt0.S
+++ b/runtime/ngdevkit-crt0.S
@@ -166,41 +166,54 @@ rom_mvs_startup_init_default:
  */
 init_c_runtime:
 	/* zero out BSS segment */
-	moveq.l	#0, %d1
 	moveq.l	#0, %d2
 	moveq.l	#0, %d3
 	moveq.l	#0, %d4
 	moveq.l	#0, %d5
 	moveq.l	#0, %d6
 	moveq.l	#0, %d7
-	sub.l	%a0, %a0
+	movea.l	%d7, %a0
+	movea.l	%d7, %a1
 
-	movea.l	#__bss_start_in_ram, %a2
+	movea.l	#__bss_start_in_ram, %a3
 	move.l	#__bss_end, %d0
 	sub.l	#__bss_start, %d0
 	lsr.w	#5, %d0
+
 .Lcopybss:
-	movem.l	%d1-%d7/%a0, (%a2)
-	lea.l	0x20(%a2), %a2
+	movem.l	%d2-%d7/%a0-%a1, (%a3)
+	lea.l	0x20(%a3), %a3
 	dbra	%d0, .Lcopybss
 
 	move.b	%d0, REG_WATCHDOGW /* kick watchdog */
 
 	/* copy data segment from ROM to RAM */
-	movea.l	#__data_start, %a1
-	movea.l	#__data_start_in_ram, %a2
+	movea.l	#__data_start, %a2
+	movea.l	#__data_start_in_ram, %a3
 	move.l	#__data_end, %d0
 	sub.l	#__data_start, %d0
+	move.w	%d0, %d1
 	lsr.w	#5, %d0
+	andi.w	#0x001F, %d1
+	bra	.Lcopydata_begin
+
 .Lcopydata:
-	movem.l	(%a1)+, %d1-%d7/%a0
-	movem.l	%d1-%d7/%a0, (%a2)
-	lea.l	0x20(%a2), %a2
+	movem.l	(%a2)+, %d2-%d7/%a0-%a1
+	movem.l	%d2-%d7/%a0-%a1, (%a3)
+	lea.l	0x20(%a3), %a3
+.Lcopydata_begin:
 	dbra	%d0, .Lcopydata
+
+	/* copy last 0-31 bytes one at a time for cleanliness */
+	bra	.Lcopylastdata_begin
+.Lcopylastdata:
+	move.b	(%a2)+, (%a3)+
+.Lcopylastdata_begin:
+	dbra	%d1, .Lcopylastdata
 
 	move.b	%d0, REG_WATCHDOGW /* kick watchdog */
 
-        rts
+	rts
 
 rom_title_default:
         /* Disable IRQs, as we don't want C code to be

--- a/runtime/ngdevkit-crt0.S
+++ b/runtime/ngdevkit-crt0.S
@@ -165,31 +165,41 @@ rom_mvs_startup_init_default:
  * Load the data and BSS segments in RAM
  */
 init_c_runtime:
-	/* copy data segment from ROM to RAM */
-	move.l	#__data_end, %d0
-	sub.l	#__data_start, %d0
-	movea.l	#__data_start, %a0
-	movea.l	#__data_start_in_ram, %a1
-	tst	%d0
-	beq	.Lclearbss
-.Lcopydata:
-	move.b	(%a0)+, (%a1)+
-	move.b	%d0, REG_WATCHDOGW
-	dbra	%d0, .Lcopydata
+	/* zero out BSS segment */
+	moveq.l	#0, %d1
+	moveq.l	#0, %d2
+	moveq.l	#0, %d3
+	moveq.l	#0, %d4
+	moveq.l	#0, %d5
+	moveq.l	#0, %d6
+	moveq.l	#0, %d7
+	sub.l	%a0, %a0
 
-.Lclearbss:
-	/* Zero out bss segment */
-	movea.l	#__bss_start_in_ram, %a0
+	movea.l	#__bss_start_in_ram, %a2
 	move.l	#__bss_end, %d0
 	sub.l	#__bss_start, %d0
-	tst	%d0
-	beq	.Linitdone
+	lsr.w	#5, %d0
 .Lcopybss:
-	move.b	#0, (%a0)+
-	move.b	%d0, REG_WATCHDOGW
+	movem.l	%d1-%d7/%a0, (%a2)
+	lea.l	0x20(%a2), %a2
 	dbra	%d0, .Lcopybss
 
-.Linitdone:
+	move.b	%d0, REG_WATCHDOGW /* kick watchdog */
+
+	/* copy data segment from ROM to RAM */
+	movea.l	#__data_start, %a1
+	movea.l	#__data_start_in_ram, %a2
+	move.l	#__data_end, %d0
+	sub.l	#__data_start, %d0
+	lsr.w	#5, %d0
+.Lcopydata:
+	movem.l	(%a1)+, %d1-%d7/%a0
+	movem.l	%d1-%d7/%a0, (%a2)
+	lea.l	0x20(%a2), %a2
+	dbra	%d0, .Lcopydata
+
+	move.b	%d0, REG_WATCHDOGW /* kick watchdog */
+
         rts
 
 rom_title_default:


### PR DESCRIPTION
Instead of clearing or overwriting memory one byte at a time, take advantage of the fact that #__bss_start_in_ram and #__data_start_in_ram are already guaranteed to be long-aligned, reserve d1-d7 and a0, and movem from them directly into the correct locations. This speeds up the initialization sequence for larger programs by a couple orders of magnitude.

~~Because this code works in blocks of 32 bytes only, some chaff is left over at the end of user memory (from 1 to 32 bytes worth). I don't consider this an issue, because:~~
- ~~That area is the heap, used for dynamic allocation, and using it without clearing it out yourself is _already_ undefined behavior, and~~
- ~~The previous code also left a byte of chaff in the same location due to an off-by-one mistake.~~

The BSS segment is also initialized before the data segment, to avoid a bug that the original code could occasionally encounter:  Because it was off by one in its calculations, clearing out the BSS segment could result in clobbering the first byte of the data segment, if there was no padding between the end of the BSS segment and the start of the data segment (aka: if the length of the BSS segment was a multiple of 4).

In addition, the watchdog is only kicked once at the end of each loop, because they now are fast enough that the watchdog resetting the system is no longer a concern in even the worst cases, and it confers yet another speedup.