### PR TITLE
Fix bss and data segments sometimes getting displaced (yes, again)

### DIFF
--- a/runtime/ngdevkit.ld
+++ b/runtime/ngdevkit.ld
@@ -71,11 +71,6 @@ SECTIONS {
     rom_mem_backup = DEFINED(rom_mem_backup)? rom_mem_backup : ORIGIN(RAM);
     rom_mem_backup_size = DEFINED(rom_mem_backup_size)? rom_mem_backup_size : SIZEOF(.bss.bram);
 
-    /* By default, .bss segment is allocated right after the backup RAM.
-     * If the later is configured manually, .bss starts at the beginning of RAM.
-     */
-    __bss_start_in_ram = (rom_mem_backup == ORIGIN(RAM)) ? (rom_mem_backup + rom_mem_backup_size + 3) /4 * 4 : ORIGIN(RAM);
-
     /* Make sure crt0 is linked first */
     *ngdevkit-crt0.o(.text)
 
@@ -133,7 +128,11 @@ SECTIONS {
     *libngdevkit.a:bios-ram.o(.bss)
   } >BIOSRAM =0xffffffff
 
+  /* By default, .bss segment is allocated right after the backup RAM.
+   * If the latter is configured manually, .bss starts at the beginning of RAM.
+   */
   __bss_start = __rodata_end ;
+  __bss_start_in_ram = (rom_mem_backup == ORIGIN(RAM)) ? (ORIGIN(RAM) + SIZEOF(.bss.bram) + 3) / 4 * 4 : ORIGIN(RAM);
   .bss __bss_start_in_ram : AT(__rodata_end) {
     /* The devkit's static libraries are linked first */
     *libgcc.a:*(.bss .bss.*)


### PR DESCRIPTION
So, while everything looked fine and dandy with the last commit to fix backup RAM when I ran it through the example suite, as soon as I started actually working on the project I've been working on again, I encountered a ton of things getting clobbered once more; moreover, things in the data section appeared to be getting initialized to 0 instead of their expected values. Debugging in MAME showed that the data section's contents were in fact sitting in memory, right where I expected them, but the code wasn't ever touching them afterwards and was writing somewhere else...

...an hour of pulling my hair out later and checking the symbols in the resulting ELF file with a fine toothed comb, the symbol for literally every variable that was defined in the bss and data sections were offset by exactly the size of the backup RAM section, while `__bss_start_in_memory` and `__data_start_in_memory` held the values I actually expected them to have.

Linkscripts are cursed.