### PR TITLE
docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:20.04
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt update -y && apt install -y autoconf autoconf-archive automake gcc curl zip unzip \
+libsdl2-dev python3-pygame libreadline-dev git
+# make sure you have src packages enabled for dependency information
+RUN echo "deb-src http://archive.ubuntu.com/ubuntu/ focal main restricted" > /etc/apt/sources.list.d/ngdevkit.list
+RUN echo "deb-src http://archive.ubuntu.com/ubuntu/ focal universe" >> /etc/apt/sources.list.d/ngdevkit.list
+RUN apt update -y
+# install build-dependency packages
+RUN export GCC_VERSION_PKG=`apt-cache depends gcc | awk '/Depends.*gcc/ {print $2}'` \
+&& echo "GCC_VERSION_PKG=$GCC_VERSION_PKG" \
+&& apt build-dep -y $GCC_VERSION_PKG \
+&& apt build-dep -y --arch-only sdcc
+# optional: install GLEW for OpenGL+GLSL shaders in GnGeo
+RUN apt install -y libglew-dev
+# dependencies for the example ROMs
+RUN apt install -y imagemagick sox libsox-fmt-mp3
+
+## Building the toolchain
+WORKDIR /ngdevkit
+COPY . .
+RUN autoreconf -iv \
+&& ./configure --prefix=$PWD/local \
+&& make \
+&& make install
+
+# ngdevkit-gngeo
+RUN make shellinit >> ~/.bashrc

--- a/Makefile.docker
+++ b/Makefile.docker
@@ -1,0 +1,13 @@
+docker:
+	docker build . -t ndevkit
+
+shell:	docker
+	docker run -it --rm -v `pwd`:/tmp/workdir -w /tmp/workdir ndevkit bash
+
+USER=hldtux
+IMAGE=ndevkit
+TAGNAME=latest
+push:
+	docker tag ${IMAGE} ${USER}/${IMAGE}:${TAGNAME}
+	docker push ${USER}/${IMAGE}:${TAGNAME}
+

--- a/README-docker.md
+++ b/README-docker.md
@@ -1,0 +1,25 @@
+# Building ngdevkit from source on any platform that supports Docker
+
+## Pre-requisite
+
+* Docker
+
+### Shell
+The following command will let access the container that contains the embedded devkit and the current folder at /tmp/workdir. So, you will be able to make the build your on rom easily without any local dependency
+
+```shell
+make -f Makefile.docker shell
+```
+
+### Push
+To avoid waiting the image creating you can push the finished one as following
+
+```shell
+make -f Makefile.docker USER=<YOUR_DOCKERHUB_USER> push
+```
+
+Congratulations! You are now ready to experiment with the devkit.
+Please follow the [main README](README.md) for additional information
+on how to download and build the example ROMs, run the emulator or
+run the debugger.
+

--- a/README.md
+++ b/README.md
@@ -134,6 +134,11 @@ For macOS, make sure you use brew's python3 and gmake:
     ./configure
     gmake
 
+For any platform that supports docker
+
+```shell
+make -f Makefile.docker shell
+```
 
 ### Running the emulator
 


### PR DESCRIPTION
# Building rom with docker

## Pre-requisite

* Docker

## Shell
The following command will let you access the container that contains the embedded devkit and the current folder at /tmp/workdir. 
So, you will be able to make the build of your rom easily without any local dependency

```shell
make -f Makefile.docker shell
```
## Building examples
```shell
git clone --recursive https://github.com/dciabrin/ngdevkit-examples examples
cd examples
./configure
cd 01-helloworld
make
```
The zipped rom will be in storage at **rom/puzzledp.zip** 

## Running
Tested on retroarch using the core **FB Alpha 2012 NeoGeo**
![image](https://github.com/dciabrin/ngdevkit/assets/9255997/106a32ab-7078-49de-ae83-ee43488e4d36)
