### PR TITLE
Tiletool: Switch str to bytes.

### DIFF
--- a/tools/tiletool.py
+++ b/tools/tiletool.py
@@ -242,8 +242,8 @@ class sprite_converter(converter):
         if self.size:
             padding=self.size-self.fd1.tell();
             if padding>0:
-                self.fd1.write('\0'*padding)
-                self.fd2.write('\0'*padding)
+                self.fd1.write(bytes.fromhex("00")*padding)
+                self.fd2.write(bytes.fromhex("00")*padding)
         self.fd1.close()
         self.fd2.close()
 


### PR DESCRIPTION
When padding a sprite with `0x00`, `tiletool.py` is erroring out with:

```
Traceback (most recent call last):
  File "/workspaces/ngdevkit/tools/./tiletool.py", line 379, in <module>
    main()
  File "/workspaces/ngdevkit/tools/./tiletool.py", line 375, in main
    conv.create()
  File "/workspaces/ngdevkit/tools/./tiletool.py", line 151, in create
    self.close_rom()
  File "/workspaces/ngdevkit/tools/./tiletool.py", line 245, in close_rom
    self.fd1.write('\0'*padding)
TypeError: a bytes-like object is required, not 'str'
```