### PR TITLE
Enable interrupts before jumping to PLAYER_START

### DIFF
--- a/nullbios/biosstart.S
+++ b/nullbios/biosstart.S
@@ -346,6 +346,7 @@ SYSTEM_IO:
 #endif
 .Lend_of_coin_prechecks:
         move.b  %d0, BIOS_START_FLAG
+	move.w  #$2000,%sr
         jsr     PLAYER_START.l
         cmp.b   #2, BIOS_USER_MODE
         bne     .Lnostart


### PR DESCRIPTION
When there are enough credits and the player presses "start", the BIOS should jump to PLAYER_START. But interrupts must be re-enabled before this, because VBLANK has not returned 'rte' to re-enable VBLANK interrupts.