### PR TITLE
Add ng-input.h with edge-detect helpers around bios_p1current/change

### DIFF
--- a/include/ngdevkit/ng-input.h
+++ b/include/ngdevkit/ng-input.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2026 Ismaïl Dogru
+ * This file is part of ngdevkit
+ *
+ * ngdevkit is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * ngdevkit is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with ngdevkit.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef __NGDEVKIT_NG_INPUT_H__
+#define __NGDEVKIT_NG_INPUT_H__
+
+#include <ngdevkit/bios-ram.h>
+#include <ngdevkit/types.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/// True while any bit in mask is currently held on player 1
+static inline u8 ng_p1_held(u8 mask)
+{
+    return (bios_p1current & mask) != 0;
+}
+
+/// True on the single frame any bit in mask transitions released -> held
+static inline u8 ng_p1_pressed(u8 mask)
+{
+    return (bios_p1current & ~bios_p1previous & mask) != 0;
+}
+
+/// True on the single frame any bit in mask transitions held -> released
+static inline u8 ng_p1_released(u8 mask)
+{
+    return (bios_p1previous & ~bios_p1current & mask) != 0;
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __NGDEVKIT_NG_INPUT_H__ */


### PR DESCRIPTION
Every example reimplements rising-edge / falling-edge detection inline against bios_p1current and bios_p1change. Three static inline helpers in a new ng-input.h name the BIOS input convention in one place:

    ng_p1_held(mask)      -> (bios_p1current & mask) != 0
    ng_p1_pressed(mask)   -> (bios_p1change & bios_p1current & mask) != 0
    ng_p1_released(mask)  -> (bios_p1change & ~bios_p1current & mask) != 0

Inline so zero call overhead.

Before:

```
for (;;) {
    if (bios_p1current & CNT_RIGHT) {
        hero_x++;
    }
    if ((bios_p1change & bios_p1current) & CNT_A) {
        play_sound(jump);
        hero_vy = -8;
    }
    if ((bios_p1change & ~bios_p1current) & CNT_A) {
        // released A while jumping → short hop
        if (hero_vy < 0) hero_vy >>= 1;
    }
    ng_wait_vblank();
}
```
With ng-input.h:

```
#include <ngdevkit/ng-input.h>

for (;;) {
    if (ng_p1_held(CNT_RIGHT)) {
        hero_x++;
    }
    if (ng_p1_pressed(CNT_A)) {
        play_sound(jump);
        hero_vy = -8;
    }
    if (ng_p1_released(CNT_A) && hero_vy < 0) {
        hero_vy >>= 1;
    }
    ng_wait_vblank();
}
```
Same emitted m68k.
I can do this for P2