### PR TITLE
Add memory clobber to WITH_BACKUP_RAM_RW asm

### DIFF
--- a/nullbios/utils.h
+++ b/nullbios/utils.h
@@ -20,10 +20,10 @@
 #ifndef __NULLBIOS_UTILS_H__
 #define __NULLBIOS_UTILS_H__
 
-#define WITH_BACKUP_RAM_RW(x) {                   \
-    __asm__ volatile ("move.b  %d0, 0x3a001d.l"); \
-    x                                             \
-    __asm__ volatile ("move.b  %d0, 0x3a000d.l"); \
+#define WITH_BACKUP_RAM_RW(x) {                                  \
+    __asm__ volatile ("move.b  %d0, 0x3a001d.l" ::: "memory");   \
+    x                                                            \
+    __asm__ volatile ("move.b  %d0, 0x3a000d.l" ::: "memory");   \
     }
 
 #define CC_CLEAR_X_FLAG()                                        \


### PR DESCRIPTION
Without a memory clobber, gcc -O2 may reorder reads/writes of backup-RAM globals across the unlock/lock pair in WITH_BACKUP_RAM_RW, defeating the protection. Adding ::: "memory" to both __asm__ volatile blocks makes them proper compiler barriers without changing emitted code for the asm itself.


Code example:

```
WITH_BACKUP_RAM_RW({
    high_score = new_score;       // BRAM write
    save_count = save_count + 1;  // BRAM write
});
some_other_global = 0;            // non-BRAM
```
Without "memory", gcc might rearrange to:

```
unlock_asm();
some_other_global = 0;            // moved INTO the protected section (harmless but pointless)
high_score = new_score;
lock_asm();
save_count = save_count + 1;      // moved OUT to AFTER the lock — bug!
```
The save_count write happens while BRAM is re-locked → hardware rejects the write → save data corrupted on the next save cycle.