### PR TITLE
fix: require Python 3.11 minimum for typing.Self (closes #128)

### DIFF
--- a/tools/vromtool.py
+++ b/tools/vromtool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python3.11
 # Copyright (c) 2024 Damien Ciabrini
 # This file is part of ngdevkit
 #


### PR DESCRIPTION
## What
The build fails on systems with Python < 3.11 (e.g., macOS Xcode Python 3.9) because `typing.Self` is used but only available since Python 3.11 (PEP 673).

## Fix
Change the shebang line from `#!/usr/bin/env python3` to `#!/usr/bin/env python3.11` to enforce Python 3.11 as minimum.

Closes #128