### PR TITLE
Add support for the NEO cartridge format in romtool

### DIFF
--- a/tools/romtool.py
+++ b/tools/romtool.py
@@ -332,6 +332,110 @@ def zip_build_cartridge(cart: Cartridge, output: str, **kwargs: OptionType):
 
 
 #
+# NEO specialization, ROM build function
+# Single-file cartridge format used by the NeoSD flashcart, the
+# Geolith emulator and the MiSTer Neo Geo core.
+#
+
+
+class NeoGenre(IntEnum):
+    OTHER = 0
+    ACTION = 1
+    BEAT_EM_UP = 2
+    SPORTS = 3
+    DRIVING = 4
+    PLATFORMER = 5
+    MAHJONG = 6
+    SHOOTER = 7
+    QUIZ = 8
+    FIGHTING = 9
+    PUZZLE = 10
+
+
+def neo_genre(name: str) -> NeoGenre:
+    """
+    Look up a NEO genre from a human-readable name, e.g. 'BeatEmUp'.
+    """
+    genres = {g.name.replace("_", ""): g for g in NeoGenre}
+    genre = genres.get(name.upper().replace("_", ""))
+    if genre is None:
+        valid = ", ".join([g.name for g in NeoGenre])
+        raise ValueError(f"unknown NEO genre '{name}', expecting one of {valid}")
+    return genre
+
+
+def neo_build_cartridge(cart: Cartridge, output: str, **kwargs: OptionType):
+    """
+    Build a cartridge file in the NEO format (version 1).
+    The file consists of a 4KiB header with the cartridge's metadata,
+    followed by the data of all the ROM regions, concatenated in
+    P, S, M, V1, V2, C order.
+    """
+
+    def read(rom: ROM) -> bytes:
+        with open(rom.path, "rb") as f:
+            return f.read()
+
+    def pad(data: bytes, multiple: int) -> bytes:
+        if len(data) % multiple == 0:
+            return data
+        return data + b"\xff" * (multiple - (len(data) % multiple))
+
+    def concat(roms: list[ROM], multiple: int = 64 * 1024) -> bytes:
+        return pad(b"".join([read(r) for r in roms]), multiple)
+
+    def interleave(even: bytes, odd: bytes) -> bytes:
+        out = bytearray(len(even) + len(odd))
+        out[0::2] = even
+        out[1::2] = odd
+        return bytes(out)
+
+    pdata = concat(cart.proms)
+    sdata = concat(cart.sroms)
+    mdata = concat(cart.mroms)
+    # ngdevkit generates a single ADPCM region, so all the samples go
+    # into V1 and the V2 region stays empty
+    v1data = concat(cart.vroms)
+    # the NEO format stores C-ROM data as seen by the hardware: every
+    # (c1, c2) pair of ROM files is byte-interleaved into a single bank
+    cpairs = []
+    for c_even, c_odd in zip(cart.croms[0::2], cart.croms[1::2]):
+        even, odd = read(c_even), read(c_odd)
+        if len(even) != len(odd):
+            raise ValueError(
+                f"C-ROMs {c_even.name} and {c_odd.name} form a pair "
+                "and must have the same size"
+            )
+        cpairs.append(interleave(even, odd))
+    cdata = pad(b"".join(cpairs), 256 * 1024)
+
+    for k in kwargs:
+        if k not in ("genre", "screenshot", "ngh"):
+            raise ValueError(f"unknown keyword '{k}' for the neo format")
+        if not isinstance(kwargs[k], str):
+            raise ValueError(f"keyword '{k}' must be of type str")
+    genre = neo_genre(typing.cast(str, kwargs.get("genre", "Other")))
+    screenshot = int(typing.cast(str, kwargs.get("screenshot", "0")))
+    # the NGH number is a hex-looking game id, e.g. NGH-041 is 0x041
+    ngh = int(typing.cast(str, kwargs.get("ngh", "0")), 16)
+
+    out = bytearray()
+    out += struct.pack("3sB", "NEO".encode(), 1)
+    out += struct.pack(
+        "<6I", len(pdata), len(sdata), len(mdata), len(v1data), 0, len(cdata)
+    )
+    out += struct.pack("<4I", cart.year, genre, screenshot, ngh)
+    out += struct.pack("33s", cart.long_name[:32].encode())
+    out += struct.pack("17s", cart.publisher[:16].encode())
+    # zero-fill the remainder of the 4KiB header
+    out += bytes(4096 - len(out))
+    out += pdata + sdata + mdata + v1data + cdata
+
+    with open(output, "wb") as f:
+        f.write(out)
+
+
+#
 # Command-line interface
 #
 
@@ -377,7 +481,7 @@ def cli_arguments_parser() -> argparse.ArgumentParser:
     )
 
     parser.add_argument(
-        "-f", "--format", help="ROM format (mame, gngeo)", default="mame"
+        "-f", "--format", help="ROM format (mame, gngeo, neo)", default="mame"
     )
 
     parser.add_argument(
@@ -495,7 +599,10 @@ def cli_main():
         elif args.format == "gngeo":
             gngeo_build_hash(cart, args.output, **extra.get("gngeo", {}))
     elif args.build == "cartridge":
-        zip_build_cartridge(cart, args.output, **extra.get("zip", {}))
+        if args.format == "neo":
+            neo_build_cartridge(cart, args.output, **extra.get("neo", {}))
+        else:
+            zip_build_cartridge(cart, args.output, **extra.get("zip", {}))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This adds a new cartridge output format to `romtool`: the NEO format, a single-file cartridge format originally designed for the NeoSD flashcart, and also used by the [Geolith](https://github.com/libretro/geolith-libretro) emulator and the MiSTer Neo Geo core. Geolith does not load MAME-style zip romsets, so this makes ngdevkit games directly runnable there.

## Format

The file consists of a 4KiB header (magic `NEO` + version 1, region sizes, year/genre/screenshot/NGH metadata, game name and manufacturer), followed by the ROM data in P, S, M, V1, V2, C order:

- P/S/M/V regions are the ROM files concatenated, padded with `0xff` to 64KiB
- the C region stores each (c1, c2) pair byte-interleaved (c1 on even bytes, c2 on odd), padded to 256KiB
- all ADPCM samples go into V1 and V2 stays empty, matching ngdevkit's single ADPCM region

## Usage

```
romtool -b cartridge -f neo -p rom.p1 -s rom.s1 -m rom.m1 -v rom.v1 -c rom.c1 rom.c2 \
        -n mygame -l "My Game" -y 2026 --publisher me \
        -x neo.genre=Shooter neo.ngh=041 neo.screenshot=0 -o mygame.neo
```

The `-x neo.*` extras are optional: genre defaults to `Other`, and NGH/screenshot default to 0, which is appropriate for homebrew (emulators only use the NGH id to apply per-game quirks for commercial titles).

## Validation

The generated files are byte-identical to the ones produced by the reference converter ([neosdconv](https://github.com/city41/neosdconv)), tested with one and two C-ROM pairs, including region sizes that exercise the padding. The existing mame/gngeo/zip code paths are unchanged.

Note: neosdconv swaps the two megabytes of a 2MiB P-ROM because commercial MAME dumps store the banked megabyte first. This is deliberately not replicated here, since ngdevkit build outputs are already in linear 68k address order, consistent with how the MAME hash backend loads them.