### PR TITLE
Make ngdevkit.pc relocatable via ${pcfiledir}

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -92,7 +92,9 @@ install-tools:
 
 install-pkgconfig:
 	$(INSTALL) -d $(DESTDIR)$(prefix)/share/pkgconfig && \
-	$(INSTALL) ngdevkit.pc $(DESTDIR)$(prefix)/share/pkgconfig
+	$(INSTALL) ngdevkit.pc $(DESTDIR)$(prefix)/share/pkgconfig && \
+	$(INSTALL) -d $(DESTDIR)$(prefix)/lib/pkgconfig && \
+	$(INSTALL) ngdevkit.pc $(DESTDIR)$(prefix)/lib/pkgconfig
 
 clean-tools:
 	set -e; \

--- a/ngdevkit.pc.in
+++ b/ngdevkit.pc.in
@@ -1,13 +1,19 @@
 # ngdevkit pkg-config source file
+#
+# All paths are resolved relative to the location of this file (${pcfiledir})
+# rather than being baked in at configure time. This keeps an installed tree
+# relocatable: extract it anywhere, point PKG_CONFIG_PATH at
+# <tree>/lib/pkgconfig (or <tree>/share/pkgconfig), and it just works. The file
+# is installed two levels below the tree root, so ${pcfiledir}/../.. is prefix.
 
-prefix=@prefix@
-exec_prefix=@exec_prefix@
-bindir=@bindir@
-libdir=@prefix@/m68k-neogeo-elf/lib
-includedir=@prefix@/m68k-neogeo-elf/include
-sharedir=@datarootdir@/ngdevkit
-z80includedir=@prefix@/z80-neogeo-ihx/include
-z80libdir=@prefix@/z80-neogeo-ihx/lib
+prefix=${pcfiledir}/../..
+exec_prefix=${prefix}
+bindir=${exec_prefix}/bin
+libdir=${prefix}/m68k-neogeo-elf/lib
+includedir=${prefix}/m68k-neogeo-elf/include
+sharedir=${prefix}/share/ngdevkit
+z80includedir=${prefix}/z80-neogeo-ihx/include
+z80libdir=${prefix}/z80-neogeo-ihx/lib
 
 Name: ngdevkit
 Description: Opensource development for the Neo-Geo


### PR DESCRIPTION
Resolve every path in `ngdevkit.pc` from `${pcfiledir}` rather than baking
in configure-time absolute paths, so an installed tree can be extracted
anywhere and used by pointing `PKG_CONFIG_PATH` at its `pkgconfig` dir.
The file is installed two levels below the tree root, so `${pcfiledir}/../..`
is the prefix.

Also install `ngdevkit.pc` to `lib/pkgconfig` in addition to
`share/pkgconfig`, matching the more conventional discovery location.

### Why

An `ngdevkit.pc` with absolute `@prefix@`-derived paths only works where it
was configured. Deriving paths from `${pcfiledir}` makes an installed tree
relocatable, which is a prerequisite for shipping prebuilt, distro-agnostic
archives.

### Notes

This is split out of a larger nightly binary-tarballs change; the tarball
build relies on this relocatable `.pc` but is being proposed separately.