### PR TITLE
Build without sudo requirements with default prefix

### DIFF
--- a/Makefile.config.in
+++ b/Makefile.config.in
@@ -23,13 +23,17 @@ EXTERNAL_GNGEO=@EXTERNAL_GNGEO@
 EXTERNAL_QCRT=@EXTERNAL_QCRT@
 EXAMPLES=@EXAMPLES@
 
+# build directory from subdirectories
+BUILD=../build
+
 # toolkit binaries
 NGAR=@ngar@
+NGRANLIB=@ngranlib@
+NGOBJCOPY=@ngobjcopy@
+NGLD=@ngld@
 NGAS=@ngas@
 NGGCC=@nggcc@
-NGLD=@ngld@
-NGOBJCOPY=@ngobjcopy@
-NGRANLIB=@ngranlib@
+NGGCCLD=@nggccld@
 NGSDAR=@ngsdar@
 NGSDAS=@ngsdas@
 NGSDCC=@ngsdcc@

--- a/Makefile.in
+++ b/Makefile.in
@@ -34,15 +34,12 @@ install: install-tools install-pkgconfig
 
 clean: clean-tools
 
-clean:
-	rm -rf local/*
-
 distclean: clean clean-pkgconfig
-	rm -rf build local config.log config.status
+	rm -rf build config.log config.status
 	find . \( -name '*~' -or -name Makefile -or -name Makefile.config \) \
 	-exec rm {} \;
 
-build local:
+build:
 	mkdir $@
 
 .PHONY: clean distclean
@@ -52,7 +49,8 @@ build local:
 # ------ toolchain (gcc, binutils, newlib, gdb) ------
 
 ifeq ($(EXTERNAL_TOOLCHAIN), no)
-build-tools: build-toolchain | $(prefix)/bin
+build-tools: build-toolchain
+install-tools: install-toolchain
 distclean: distclean-toolchain
 endif
 
@@ -125,7 +123,7 @@ distclean-examples:
 
 ifeq ($(EXTERNAL_EMUDBG), no)
 all: build-emudbg
-build-gngeo: install-emudbg
+build-gngeo: build-emudbg
 install: install-emudbg
 distclean: distclean-emudbg
 endif
@@ -190,7 +188,7 @@ build/gngeo: gngeo
 	mkdir -p build/gngeo && \
 	cd build/gngeo && \
 	$$CURPWD/gngeo/configure --program-prefix=ngdevkit- $(GNGEO_BUILD_FLAGS) \
-	CPPFLAGS="$$CPPFLAGS -Wno-implicit-function-declaration -I$(prefix)/include" CFLAGS="$$CFLAGS -Wno-implicit-function-declaration -I$(prefix)/include -DGNGEORC=\\\"ngdevkit-gngeorc\\\"" LDFLAGS="-L$(prefix)/lib" PKG_CONFIG_PATH="$(prefix)/lib/pkgconfig" \
+	CPPFLAGS="$$CPPFLAGS -Wno-implicit-function-declaration -I$$CURPWD/emudbg/src -I$(prefix)/include" CFLAGS="$$CFLAGS -Wno-implicit-function-declaration -I$$CURPWD/emudbg/src -I$(prefix)/include -DGNGEORC=\\\"ngdevkit-gngeorc\\\"" LDFLAGS="-L$$PWD/../emudbg/src -L$(prefix)/lib" PKG_CONFIG_PATH="$$PWD/../emudbg:$(prefix)/lib/pkgconfig" \
 	-v && $(MAKE) -j1 pkgdatadir=$(GNGEOPKGDATADIR)
 
 install-gngeo: $(GNGEO)

--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,8 @@ dnl if ngdevkit-toolkit is already installed system-wide, use it
 if test x"$EXTERNAL_TOOLCHAIN" = x"yes"; then
 AC_PATH_PROG([nggcc], [m68k-neogeo-elf-gcc], [no])
 AS_IF([test x"$nggcc" = x"no"], [AC_MSG_ERROR([m68k-neogeo-elf-gcc not found in path.])])
+nggccld="$nggcc"
+AC_SUBST([nggccld])
 AC_PATH_PROG([ngas], [m68k-neogeo-elf-as], [no])
 AS_IF([test x"$ngas" = x"no"], [AC_MSG_ERROR([m68k-neogeo-elf-as not found in path.])])
 AC_PATH_PROG([ngld], [m68k-neogeo-elf-ld], [no])
@@ -102,18 +104,19 @@ fi
 
 else
 dnl Otherwise we'll build it
-nggcc=$prefix/bin/m68k-neogeo-elf-gcc
-ngas=$prefix/bin/m68k-neogeo-elf-as
-ngld=$prefix/bin/m68k-neogeo-elf-ld
-ngar=$prefix/bin/m68k-neogeo-elf-ar
-ngranlib=$prefix/bin/m68k-neogeo-elf-ranlib
-ngobjcopy=$prefix/bin/m68k-neogeo-elf-objcopy
-ngsdcc=$prefix/bin/z80-neogeo-ihx-sdcc
-ngsdas=$prefix/bin/z80-neogeo-ihx-sdasz80
-ngsdld=$prefix/bin/z80-neogeo-ihx-sdldz80
-ngsdar=$prefix/bin/z80-neogeo-ihx-sdar
-ngsdranlib=$prefix/bin/z80-neogeo-ihx-sdranlib
-ngsdobjcopy=$prefix/bin/z80-neogeo-ihx-sdobjcopy
+ngar='$(BUILD)/ngbinutils/binutils/ar'
+ngranlib='$(BUILD)/ngbinutils/binutils/ranlib'
+ngobjcopy='$(BUILD)/ngbinutils/binutils/objcopy'
+ngld='$(BUILD)/ngbinutils/binutils/ld/ld-new'
+ngas='$(BUILD)/ngbinutils/binutils/gas/as-new'
+nggcc='$(BUILD)/nggcc/gcc/xgcc -B $(BUILD)/nggcc/gcc -isystem $(BUILD)/nggcc/gcc/include'
+nggccld='$(BUILD)/nggcc/gcc/xgcc -B $(BUILD)/nggcc/gcc -L $(BUILD)/ngnewlib/m68k-neogeo-elf/newlib'
+ngsdar='$(BUILD)/ngsdcc/bin/sdar'
+ngsdas='$(BUILD)/ngsdcc/bin/sdasz80'
+ngsdcc='$(BUILD)/ngsdcc/bin/sdcc'
+ngsdld='$(BUILD)/ngsdcc/bin/sdldz80'
+ngsdobjcopy='$(BUILD)/ngsdcc/bin/sdobjcopy'
+ngsdranlib='$(BUILD)/ngsdcc/bin/sdranlib'
 fi
 
 

--- a/nullbios/Makefile.in
+++ b/nullbios/Makefile.in
@@ -83,13 +83,13 @@ bios-ram.o: BIOSOPTS=-O0
 	$(NGGCC) $(BIOSCFLAGS) $(BIOSOPTS) -c $< -o $@
 
 sp-s2.elf: sp-s2.o $(BIOS_OBJS:%=%.o)
-	$(NGGCC) $(BIOSLDFLAGS) $^ -lngdevkit -o $@
+	$(NGGCCLD) $(BIOSLDFLAGS) $^ -lngdevkit -o $@
 
 sp-s2.o: biosstart.S
 	$(NGGCC) -DBIOS_ROM_HARDWARE=1 -DBIOS_ROM_COUNTRY=2 -I../include -c $< -o $@
 
 aes-bios.elf: aes-bios.o $(BIOS_OBJS:%=%.o)
-	$(NGGCC) $(BIOSLDFLAGS) $^ -lngdevkit -o $@
+	$(NGGCCLD) $(BIOSLDFLAGS) $^ -lngdevkit -o $@
 
 aes-bios.o: biosstart.S
 	$(NGGCC) -DBIOS_ROM_HARDWARE=0 -DBIOS_ROM_COUNTRY=2 -I../include -c $< -o $@

--- a/runtime/Makefile.in
+++ b/runtime/Makefile.in
@@ -85,16 +85,16 @@ ngdevkit-cd-crt0.o: ngdevkit-crt0.S
 install: install-objs install-specs
 
 install-dirs:
-	OBJDIR=$(DESTDIR)$(prefix)/$$(dirname $$($(NGGCC) --print-file-name=crt0.o) | sed -n 's%^.*\(m68k-neogeo-elf/lib/gcc\)%\1%p') && \
-	SPECSDIR=$(DESTDIR)$(prefix)/$$(dirname $$($(NGGCC) --print-libgcc-file-name) | sed -n 's%^.*\(m68k-neogeo-elf/lib/gcc\)%\1%p') && \
+	OBJDIR=$(DESTDIR)$(prefix)/m68k-neogeo-elf/lib && \
+	SPECSDIR=$(DESTDIR)$(prefix)/m68k-neogeo-elf/lib/gcc/m68k-neogeo-elf/$$($(NGGCC) -dumpversion) && \
 	$(INSTALL) -d $$OBJDIR && $(INSTALL) -d $$SPECSDIR
 
 install-objs: install-dirs $(OBJS) ngdevkit.ld
-	DIR=$(DESTDIR)$(prefix)/$$(dirname $$($(NGGCC) --print-file-name=crt0.o) | sed -n 's%^.*\(m68k-neogeo-elf/lib/gcc\)%\1%p') && \
+	DIR=$(DESTDIR)$(prefix)/m68k-neogeo-elf/lib && \
 	$(INSTALL) $(filter-out install-dirs,$^) $$DIR
 
 install-specs: install-dirs ngdevkit ngdevkit-cd
-	DIR=$(DESTDIR)$(prefix)/$$(dirname $$($(NGGCC) --print-libgcc-file-name) | sed -n 's%^.*\(m68k-neogeo-elf/lib/gcc\)%\1%p') && \
+	DIR=$(DESTDIR)$(prefix)/m68k-neogeo-elf/lib/gcc/m68k-neogeo-elf/$$($(NGGCC) -dumpversion) && \
 	$(INSTALL) $(filter-out install-dirs,$^) $$DIR
 
 clean:


### PR DESCRIPTION
Make the standard "./configure && make && make install" work as intended, that is, only require sudo permissions for "make install", when the permissions of prefix's path require it.

Fixes #155