### PR TITLE
Fix stream volume commands ignored at boot

### DIFF
--- a/nullsound/volume.s
+++ b/nullsound/volume.s
@@ -104,11 +104,12 @@ state_volume_adpcm_a_master_ramp::
 
 
 init_volume_state_tracker::
-        ;; reset music volume to max (no attenuation)
+        ;; reset music volume to max (no attenuation), start unmuted
         ld      a, #0x0f
         ld      (state_volume_music_level), a
-        ld      (state_volume_muted), a
         ld      (state_volume_mute_level), a
+        xor     a
+        ld      (state_volume_muted), a
         ;; reset channel levels
         ld      a, #0
         ld      (state_fm_volume_attenuation), a


### PR DESCRIPTION
init_volume_state_tracker initialised state_volume_muted to 0x0f. The mute gate in stream_volume_down and stream_volume_up returns early when it is non-zero, so the music level cannot change until an explicit volume_unmute. This initialises it to 0 so volume control works from boot.